### PR TITLE
Replaced DarkYellow with hex-equivalent, since some implementations don't recognize it.

### DIFF
--- a/after/syntax/color_coded.vim
+++ b/after/syntax/color_coded.vim
@@ -3,7 +3,7 @@
 
 hi default Member ctermfg=Cyan guifg=Cyan
 hi default Variable ctermfg=Grey guifg=Grey
-hi default Namespace ctermfg=DarkYellow guifg=DarkYellow
+hi default Namespace ctermfg=Yellow guifg=Yellow
 hi default EnumConstant ctermfg=LightGreen guifg=LightGreen
 
 hi link StructDecl Type


### PR DESCRIPTION
I know users can override it, but might as well have good defaults.

Affected implementations: Vim-qt, Macvim (?)