### PR TITLE
Ignore CMake output in case built in main directory. Required for NeoBundle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ bin
 # Clang
 /clang*
 /lib/clang*
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+color_coded.so
+install_manifest.txt
 
 # Personal notes
 NOTES


### PR DESCRIPTION
Required for #35 due to limitation at https://github.com/Shougo/neobundle.vim/issues/78.