### PR TITLE
Only display master build status and link image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-color_coded: semantic highlighting with vim ![build status](https://travis-ci.org/jeaye/color_coded.png)
+color_coded: semantic highlighting with vim [![Build Status](https://travis-ci.org/jeaye/color_coded.svg?branch=master)](https://travis-ci.org/jeaye/color_coded)
 ---
 color_coded is a vim plugin that provides realtime (fast), tagless code highlighting for C++, C, and Objective C using libclang.
 


### PR DESCRIPTION
When no branch is given, the badge will display the latest build status.
If an unrelated development branch fails, the user might think the master
is broken. Also, the image was not linking to the travis build page.