### PR TITLE
Change order of CMake includes so Boost will come first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,11 @@ endif()
 # C++14
 include(cmake/cxx14.cmake)
 
-# Lua
-include(cmake/lua.cmake)
-
 # Boost
 include(cmake/boost.cmake)
+
+# Lua
+include(cmake/lua.cmake)
 
 # Curses
 find_package(Curses REQUIRED)


### PR DESCRIPTION
When there is a copy of Boost 1.57 headers in `/usr/local/include`, compilation of the Boost version in color_coded tree fails.

In the `CMakeLists.txt` file, by including `cmake/lua.cmake` before `cmake/boost.cmake`, it adds `-I/usr/local/include` to the compiler flags before the flags for the local copy of Boost, which causes the (incompatible) headers from the newer version of Boost to be included when compiling the local Boost source, breaking the build. 