### PR TITLE
Add -Werror ro the compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set_property(TARGET color_coded PROPERTY OUTPUT_NAME "color_coded.so")
 set_property(TARGET color_coded PROPERTY SUFFIX "")
 
 # Enable warnings
-set_property(TARGET color_coded PROPERTY COMPILE_FLAGS "-Wall -Wextra -pedantic -Wno-missing-field-initializers")
+set_property(TARGET color_coded PROPERTY COMPILE_FLAGS "-Wall -Wextra -Werror -pedantic -Wno-missing-field-initializers")
 
 # Fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
 # used when making a shared object; recompile with -fPIC.


### PR DESCRIPTION
Treating compiler warnings as errors will save ourselves a lot of
headaches down the line. The compiler emits them for a reason. Plus they
look kind of ugly when compiling. As a user or possible contributor, I
would rather not have a massive wall of warnings.
Travis can also notify you when a build/PR would emit new warnings like this.
I realise that this change is a bit controversial, so what do you think about it?