### PR TITLE
Fix ambiguous syntax when calling CCerror

### DIFF
--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -150,8 +150,7 @@ endfunction!
 
 function! color_coded#last_error()
 lua << EOF
-  vim.command
-  (
+  vim.command(
     "echo \"" .. string.gsub(color_coded_last_error(), "\"", "'") ..  "\""
   )
 EOF


### PR DESCRIPTION
The lua reference manual states that "you cannot put a line break before the '(' in a function call."
This would cause the call to CCerror to fail.