### PR TITLE
Update instructions to match vim's lua version on ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,19 @@ brew install xz cmake
 #### Ubuntu/Debian
 First, install all required dependencies.
 ```bash
-sudo apt-get install build-essential libclang-3.6-dev liblua5.1-dev lua5.1 libncurses-dev libboost-dev libz-dev cmake xz-utils
+sudo apt-get install build-essential libclang-3.6-dev libncurses-dev libboost-dev libz-dev cmake xz-utils
 ```
 
-Next, you need to ensure you have GCC 4.9 (or higher). If you don't, you can try the following (tested on Ubuntu 14.04).
+For lua, you must install the version that your version of vim is compiled for.
+```bash
+vim --version | grep lua
+```
+Find your version number `-llua5.x` and use it to install the correct version.
+```bash
+sudo apt-get install liblua5.x-dev lua5.x
+```
+
+You also need to ensure you have GCC 4.9 (or higher). If you don't, you can try the following (tested on Ubuntu 14.04).
 ```bash
 # Install GCC 4.9
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
I tried installing color_coded with lua5.1 and I kept getting errors saying color_coded wasn't installed, but the compiling process seemed to work just fine.  Upon installing lua5.2 (which is what ubuntu 15.04's vim must use now) color_coded sprang to life.  I updated the instructions to hopefully help someone in a similar situation.