### PR TITLE
Switch to new travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,26 @@
 language: cpp
+
+sudo: false
+
 compiler:
   - gcc
   - clang
-before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - if [ "$CXX" == "clang++"  ]; then sudo add-apt-repository -y 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main'; fi
-  - sudo apt-get update -qq
+
+addons:
+  apt:
+    packages:
+      - clang-3.5
+      - libstdc++-4.9-dev
+      - g++-4.9
+      - liblua5.1-0-dev
+      - lua5.1
+      - libboost-dev
+    sources:
+      - llvm-toolchain-precise-3.5
+      - ubuntu-toolchain-r-test
+
 install:
-  - sudo apt-get install liblua5.1-dev lua5.1 libncurses-dev libboost-dev libz-dev
-  - if [ "$CXX" == "g++"  ]; then sudo apt-get install g++-4.9; fi
   - if [ "$CXX" == "g++"  ]; then export CXX="g++-4.9"; fi
-  - if [ "$CXX" == "clang++"  ]; then sudo apt-get install --allow-unauthenticated libstdc++-4.9-dev clang-3.5; fi
   - if [ "$CXX" == "clang++"  ]; then export CXX="clang++-3.5"; fi
 script:
   - cmake . && make && make install


### PR DESCRIPTION
Implements #74 

The new container based infrastructure offers faster boot times and caching. The apt cache is only for private repositories but might be enabled by default soon. After some experimentation I found that caching the clang download does not make a difference and is somewhat cumbersome.

libncurses-dev and libz-dev have been removed from the package list. The code compiled just fine without them. Not sure what they are used for. libz-dev is also not whitelisted.