### PR TITLE
generate_sources can now be run out-of-source.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,10 @@ include_directories(
   include
 
   ${LLVM_INCLUDE_PATH}
-
   ${CURSES_INCLUDE_PATH}
   ${ZLIB_INCLUDE_PATH}
+
+  $ENV{PWD}/include/
 )
 
 include(cmake/generate_sources.cmake)

--- a/cmake/generate_sources.cmake
+++ b/cmake/generate_sources.cmake
@@ -1,5 +1,5 @@
 message(STATUS "Generating sources")
 execute_process(
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/generate_sources
-          ${CMAKE_CURRENT_SOURCE_DIR} ${LLVM_ROOT_PATH}
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/generate_sources ${LLVM_ROOT_PATH}
+  WORKING_DIRECTORY $ENV{PWD}
 )

--- a/include/env/environment.hpp
+++ b/include/env/environment.hpp
@@ -9,4 +9,4 @@ namespace color_coded
   struct environment;
 }
 
-#include "impl.hpp"
+#include "env/impl.hpp"

--- a/lib/generate_sources
+++ b/lib/generate_sources
@@ -6,7 +6,7 @@ target=include/env/impl.hpp
 # Create directories if they don't exist
 mkdir -p include/env/
 
-# Remove the impl.hpp to create a fresth one, since the PWD changes.
+# Remove the impl.hpp to create a fresh one, since the PWD changes.
 [ -f $target ] && rm -f $target
 cat <<EOF > $target
 /* XXX: Automagically generated. No touching. */

--- a/lib/generate_sources
+++ b/lib/generate_sources
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-pwd=$1
-clang_dir=$2
-target=$pwd/include/env/impl.hpp
+clang_dir=$1
+target=include/env/impl.hpp
 
+# Create directories if they don't exist
+mkdir -p include/env/
+
+# Remove the impl.hpp to create a fresth one, since the PWD changes.
 [ -f $target ] && rm -f $target
 cat <<EOF > $target
 /* XXX: Automagically generated. No touching. */
@@ -14,7 +17,7 @@ namespace color_coded
   template <>
   struct environment<env::tag>
   {
-    static char constexpr const * const pwd{ "$pwd" };
+    static char constexpr const * const pwd{ "$PWD" };
     static char constexpr const * const clang_include
     { "-I$clang_dir/include" };
     static char constexpr const * const clang_include_cpp


### PR DESCRIPTION
generate_sources is a script that creates a header file. Currently it's configured to only build in-source, but the pull request changes this behaviour by allowing the script to be run from anywhere, and also fixes the cmake procedures to compensate for this.