### PR TITLE
Travis now builds out-of-source instead of in-source.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,11 @@ install:
   - if [ "$CXX" == "g++"  ]; then export CXX="g++-4.9"; fi
   - if [ "$CXX" == "clang++"  ]; then export CXX="clang++-3.5"; fi
 script:
-  - mkdir -p build && cd build/ && cmake .. && make && make install
-  - cd ../bin && echo "os.exit()" | lua -l color_coded && cd ..
-  - rm -rf bin && mv build/clang* . && rm -rf build
+  - export OUTSOURCE=$PWD/build
+  - export SOURCEPATH=$PWD
+  - mkdir -p $OUTSOURCE && cd $OUTSOURCE && cmake $SOURCEPATH && make && make install
+  - cd $SOURCEPATH/bin && echo "os.exit()" | lua -l color_coded
+  - cd $SOURCEPATH && rm -rf bin && mv $OUTSOURCE/clang* . && rm -rf $OUTSOURCE
   - cmake . && make && make install
-  - cd bin && echo "os.exit()" | lua -l color_coded
-  - make color_coded_test || true
+  - cd $SOURCEPATH/bin && echo "os.exit()" | lua -l color_coded
+  - cd $SOURCEPATH && make color_coded_test || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ install:
   - if [ "$CXX" == "g++"  ]; then export CXX="g++-4.9"; fi
   - if [ "$CXX" == "clang++"  ]; then export CXX="clang++-3.5"; fi
 script:
-  - mkdir -p build && cd build/ && cmake .. && make
-  - cd .. && mv build/clang* . && rm -r build/ && cmake . && make && make install
-  - echo "os.exit()" | lua -l color_coded
+  - mkdir -p build && cd build/ && cmake .. && make && make install
+  - cd ../bin && echo "os.exit()" | lua -l color_coded && cd ..
+  - rm -rf bin && mv build/clang* . && rm -rf build
+  - cmake . && make && make install
+  - cd bin && echo "os.exit()" | lua -l color_coded
   - make color_coded_test || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - if [ "$CXX" == "g++"  ]; then export CXX="g++-4.9"; fi
   - if [ "$CXX" == "clang++"  ]; then export CXX="clang++-3.5"; fi
 script:
-  - mkdir -p build && cd build/ && cmake .. && make && make install
+  - mkdir -p build && cd build/ && cmake .. && make
+  - cd .. && mv build/clang* . && rm -r build/ && cmake . && make && make install
   - echo "os.exit()" | lua -l color_coded
   - make color_coded_test || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ install:
   - if [ "$CXX" == "g++"  ]; then export CXX="g++-4.9"; fi
   - if [ "$CXX" == "clang++"  ]; then export CXX="clang++-3.5"; fi
 script:
-  - cmake . && make && make install
+  - mkdir -p build && cd build/ && cmake .. && make && make install
   - echo "os.exit()" | lua -l color_coded
   - make color_coded_test || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,10 @@ include_directories(
   include
 
   ${LLVM_INCLUDE_PATH}
-
   ${CURSES_INCLUDE_PATH}
   ${ZLIB_INCLUDE_PATH}
+
+  $ENV{PWD}/include/
 )
 
 include(cmake/generate_sources.cmake)

--- a/cmake/generate_sources.cmake
+++ b/cmake/generate_sources.cmake
@@ -1,5 +1,5 @@
 message(STATUS "Generating sources")
 execute_process(
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/generate_sources
-          ${CMAKE_CURRENT_SOURCE_DIR} ${LLVM_ROOT_PATH}
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/generate_sources ${LLVM_ROOT_PATH}
+  WORKING_DIRECTORY $ENV{PWD}
 )

--- a/include/env/environment.hpp
+++ b/include/env/environment.hpp
@@ -9,4 +9,4 @@ namespace color_coded
   struct environment;
 }
 
-#include "impl.hpp"
+#include "env/impl.hpp"

--- a/lib/generate_sources
+++ b/lib/generate_sources
@@ -6,7 +6,7 @@ target=include/env/impl.hpp
 # Create directories if they don't exist
 mkdir -p include/env/
 
-# Remove the impl.hpp to create a fresth one, since the PWD changes.
+# Remove the impl.hpp to create a fresh one, since the PWD changes.
 [ -f $target ] && rm -f $target
 cat <<EOF > $target
 /* XXX: Automagically generated. No touching. */

--- a/lib/generate_sources
+++ b/lib/generate_sources
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-pwd=$1
-clang_dir=$2
-target=$pwd/include/env/impl.hpp
+clang_dir=$1
+target=include/env/impl.hpp
 
+# Create directories if they don't exist
+mkdir -p include/env/
+
+# Remove the impl.hpp to create a fresth one, since the PWD changes.
 [ -f $target ] && rm -f $target
 cat <<EOF > $target
 /* XXX: Automagically generated. No touching. */
@@ -14,7 +17,7 @@ namespace color_coded
   template <>
   struct environment<env::tag>
   {
-    static char constexpr const * const pwd{ "$pwd" };
+    static char constexpr const * const pwd{ "$PWD" };
     static char constexpr const * const clang_include
     { "-I$clang_dir/include" };
     static char constexpr const * const clang_include_cpp


### PR DESCRIPTION
Travis used to build color_coded in its source directory, but now Travis creates a new directory if it doesn't exist, changes the working directory to the new one, and runs cmake.