### PR TITLE
Make switching to and from the "twilighted" colorscheme work as expected

### DIFF
--- a/colors/twilighted.vim
+++ b/colors/twilighted.vim
@@ -9,6 +9,7 @@ hi clear
 if exists("syntax_on")
     syntax reset
 endif
+let g:colors_name="twilighted"
 
 let b:current_syntax = &cpo
 set background=dark

--- a/colors/twilighted.vim
+++ b/colors/twilighted.vim
@@ -5,7 +5,10 @@
 let s:cpo_save = &cpo
 set cpo&vim
 
-syntax clear
+hi clear
+if exists("syntax_on")
+    syntax reset
+endif
 
 let b:current_syntax = &cpo
 set background=dark


### PR DESCRIPTION
Previously the twilighted scheme lacked some common boilerplate used by most modern Vim color schemes. The boilerplate is mainly to clear all stale highlight group settings. Otherwise, when a user switches from scheme A to B, some settings in A but not set in B will interfere the final appearance, leading to unexpected/messed-up display. Also, instead of `syntax clear`, `syntax reset` (when and only when syntax is on) is preferred in a color scheme (see "syn-clear").

To see the effect of this patch, try the following with and without the patch:

1. Start vim with "default" colorscheme. Open a C++ file or whatever.
2. `:colorscheme twilighted`
3. `:colorscheme blue`
4. `:colorscheme twilighted`

Without this patch, step 2 will lead to an appearance that is slightly from using twilighted from vimrc. Step 3 will lose the syntax highlighting (because of the wrongly used `syntax clear`). And step 4 will cause a totally messed-up highlight setting (because of the uncleared stale highlight settings). Yet with this patch, everything is fixed.