### PR TITLE
Fix path in config file test

### DIFF
--- a/test/include/config.hpp
+++ b/test/include/config.hpp
@@ -91,7 +91,9 @@ namespace jest
       std::find
       (
         args.begin(), args.end(),
-        std::string{ "-I" } + color_coded::environment<color_coded::env::tag>::pwd + "/test"
+        std::string{ "-I" } +
+        color_coded::environment<color_coded::env::tag>::pwd +
+        "/" + test_config_dir + "/test"
       ) != args.end()
     );
     expect(std::find(args.begin(), args.end(), "-I/etc/") != args.end());


### PR DESCRIPTION
Relative paths are resolved relative to the .color_coded file. The test
looked for a directory relative to the current working directory.

Looking at commit 62cd5632624e73cb91ecc63e9e591d34f403ae8f, this seems to be the correct behaviour and the test just had the wrong path.

With this, we could remove the ```|| true``` from the .travis.yml. Ignoring the test results in the ci build seems like a bad idea.