### PR TITLE
signal to wake up and exit is missed by queue thread, resulting in deadlock

### DIFF
--- a/include/async/queue.hpp
+++ b/include/async/queue.hpp
@@ -51,7 +51,10 @@ namespace color_coded
         void join()
         {
           should_work_.store(false);
-          wake_up_.store(true);
+          {
+            std::unique_lock<std::mutex> lock{ task_mutex_ };
+            wake_up_.store(true);
+          }
           task_cv_.notify_one();
           thread_.join();
         }


### PR DESCRIPTION
I've been running with color_coded for a bit now, and it's been really awesome! Thanks for sharing this.

One thing I did notice was that every now and then, when I exit vim that the process would hang. I did a pstack and noticed that the two threads were waiting on thread_.join() and task_cv_.wait.

I checked cppreference and it mentioned that even for atomic variables, you need to acquire the mutex to publish to the waiting thread so I made this change. Seems like its been running fine for me now. 

Figured I might as well share it and get some feedback/thoughts. 