### PR TITLE
Highlight auto like variables

### DIFF
--- a/include/clang/token.hpp
+++ b/include/clang/token.hpp
@@ -74,6 +74,9 @@ namespace color_coded
           case CXType_FunctionProto:
             return "Function";
 
+          case CXType_Auto:
+            return "Variable";
+
           default:
             return "";
             //return "Error1 " + std::to_string(kind);


### PR DESCRIPTION
Clang introduced a new type, CXType_Auto for variables that are defined
using auto. These were not highlighted by color_coded because it was
missing in the switch statement.