### PR TITLE
Preserve compatibility with clang 3.6

### DIFF
--- a/include/clang/token.hpp
+++ b/include/clang/token.hpp
@@ -73,10 +73,10 @@ namespace color_coded
           case CXType_FunctionNoProto:
           case CXType_FunctionProto:
             return "Function";
-
+#if CINDEX_VERSION_MINOR >= 32
           case CXType_Auto:
             return "Variable";
-
+#endif
           default:
             return "";
             //return "Error1 " + std::to_string(kind);


### PR DESCRIPTION
Clang 3.6 did not have the CXType_Auto enum value to denote variables of
type auto. With the new build infrastructure user can now use their
system clang instead of the one bundled with color_coded. Using
CXType_Auto however prevented users from using their older system clang
versions.

The preprocessor check checks for a #define in include/clang-c/Index.h
that gets increased after api additions.

Fixes #123 