### PR TITLE
Generated headers now always appear in the source directory

### DIFF
--- a/cmake/generate_sources.cmake
+++ b/cmake/generate_sources.cmake
@@ -1,5 +1,5 @@
 message(STATUS "Generating sources")
 execute_process(
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/generate_sources ${LLVM_ROOT_PATH}
-  WORKING_DIRECTORY $ENV{PWD}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )


### PR DESCRIPTION
Without this change, the generated files appear wherever one happens to be. This is especially bad for scripts whose working directory is not the build or source directory.