### PR TITLE
Change temporary path from $tmp/color_coded to $tmp/color_coded-$UID

### DIFF
--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0x8a20597
+let s:color_coded_api_version = 0xc2e8950
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/include/core.hpp
+++ b/include/core.hpp
@@ -33,7 +33,9 @@ namespace color_coded
 
     inline std::string temp_dir()
     {
-      static auto const dir(fs::temp_directory_path() / "color_coded/");
+      static auto const temp_dir(fs::temp_directory_path());
+      static auto const user_dir("color_coded-" + std::to_string(geteuid()) + "/");
+      static auto const dir(temp_dir / user_dir);
       static auto const make_dir(fs::create_directory(dir));
       static_cast<void>(make_dir);
       return dir.string();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0x8a20597 };
+    std::size_t constexpr const version{ 0xc2e8950 };
     lua_pushinteger(lua, version);
     return 1;
   }


### PR DESCRIPTION
If multiple users try to use the plugin on a single machine, only the
first user is capable of using it, since $tmp/color_coded is owned by
him. This fix addresses this by creating a different folder per user.

Signed-off-by: Nehal J Wani <nehaljw.kkd1@gmail.com>