### PR TITLE
Fix the default flags for search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ endif()
 if ((NOT LLVM_FOUND) OR (NOT CLANG_FOUND) OR (${DOWNLOAD_CLANG}))
 	set(DOWNLOAD_CLANG 1)
 	include(cmake/clang/download.cmake)
-	find_package(LLVM)
-	find_package(LibClang)
+	find_package(LLVM REQUIRED)
+	find_package(LibClang REQUIRED)
 endif()
 
 include_directories(

--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0x22f3ca9
+let s:color_coded_api_version = 0x970565b
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/cmake/generate_sources.cmake
+++ b/cmake/generate_sources.cmake
@@ -1,5 +1,5 @@
 message(STATUS "Generating sources")
 execute_process(
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/generate_sources ${LLVM_ROOT_PATH}
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lib/generate_sources ${LLVM_ROOT_DIR} ${LLVM_VERSION_STRING}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/include/conf/defaults.hpp
+++ b/include/conf/defaults.hpp
@@ -49,9 +49,9 @@ namespace color_coded
     {
       return
       {
+        environment<env::tag>::clang_resource_dir,
         environment<env::tag>::clang_include,
         environment<env::tag>::clang_include_cpp,
-        environment<env::tag>::clang_lib_include,
         "-isystem/usr/local/include",
         "-isystem/opt/local/include",
         "-isystem/usr/include",

--- a/lib/generate_sources
+++ b/lib/generate_sources
@@ -1,14 +1,15 @@
 #!/bin/sh
 
-clang_dir=$1
+llvm_dir=$1
+llvm_version=$2
 target=include/env/impl.hpp
 
 # Create directories if they don't exist
 mkdir -p include/env/
 
 # Remove the impl.hpp to create a fresh one, since the PWD changes.
-[ -f $target ] && rm -f $target
-cat <<EOF > $target
+[ -f "$target" ] && rm -f "$target"
+cat <<EOF > "$target"
 /* XXX: Automagically generated. No touching. */
 #pragma once
 
@@ -19,11 +20,11 @@ namespace color_coded
   {
     static char constexpr const * const pwd{ "$PWD" };
     static char constexpr const * const clang_include
-    { "-isystem$clang_dir/include" };
+    { "-isystem${llvm_dir}/include" };
     static char constexpr const * const clang_include_cpp
-    { "-isystem$clang_dir/include/c++/v1" };
-    static char constexpr const * const clang_lib_include
-    { "-isystem$clang_dir/lib/clang/3.8.0/include" };
+    { "-isystem${llvm_dir}/include/c++/v1" };
+    static char constexpr const * const clang_resource_dir
+    { "-resource-dir=${llvm_dir}/lib/clang/${llvm_version}" };
   };
 }
 EOF

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0x22f3ca9 };
+    std::size_t constexpr const version{ 0x970565b };
     lua_pushinteger(lua, version);
     return 1;
   }


### PR DESCRIPTION
Changes in the build system broke the generation of default search paths. This commit fixes the bug and furthermore removes a hard-coded version string to make it future-proof. Lastly, `-resource-dir` is used for the clang internal headers/libraries instead of `-isystem` [1].

API version was automatically updated.

Also adding two `REQUIRED` in the main `CMakeLists.txt` for completeness, as at that point they have to be present anyway. Not a big deal though.

Now if one uses the downloaded clang+llvm, they should never run into problems like #131. No hacks needed, for good.

[1] more explanation: stuff inside `lib/clang/<version>/` is indeed internal to clang and should be hidden from users (gcc has similar counterparts), containing `stddef.h`, intrinsics, etc (see related [docs](http://clang.llvm.org/doxygen/classclang_1_1HeaderSearchOptions.html#ac3915152e45f4ff70c81bd8f48947006)). Users are never expected to specify this path themselves (though unfortunately we sort of have to hack it when using libclang, as part of the logic for finding the path is in clang binary.) `-resource-dir` is the "correct", clang-specific argument to configure this path and should be more reliable (it does slightly more than `-isystem`, but in our scenario the difference is immaterial, at present.) YCM has been using `-resource-dir` for this directory too.