### PR TITLE
Ensure the order of search paths for C++

### DIFF
--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0x970565b
+let s:color_coded_api_version = 0xcfac0c1
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/include/conf/defaults.hpp
+++ b/include/conf/defaults.hpp
@@ -14,6 +14,17 @@ namespace color_coded
     /* Prefixed onto every set of args to make life easier. */
     inline args_t pre_constants(std::string const &filetype)
     {
+      /* These C++ include paths must always precede /usr/include and alike. */
+      args_t cpp_includes =
+      {
+        /* Local clang+llvm */
+        environment<env::tag>::clang_include_cpp,
+        environment<env::tag>::clang_include,
+        /* System clang on macOS */
+        "-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1",
+        "-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
+      };
+
       if(filetype == "c")
       {
         return
@@ -30,18 +41,24 @@ namespace color_coded
       }
       else if(filetype == "objective-c++")
       {
-        return
+        args_t args =
         {
-          "-x", "objective-c",
+          "-x", "objective-c++",
         };
+        std::move(cpp_includes.begin(), cpp_includes.end(),
+                  std::back_inserter(args));
+        return args;
       }
       else // C++ or something else
       {
-        return
+        args_t args =
         {
           "-x", "c++",
           "-std=c++14",
         };
+        std::move(cpp_includes.begin(), cpp_includes.end(),
+                  std::back_inserter(args));
+        return args;
       }
     }
 
@@ -49,14 +66,10 @@ namespace color_coded
     {
       return
       {
-        environment<env::tag>::clang_resource_dir,
-        environment<env::tag>::clang_include,
-        environment<env::tag>::clang_include_cpp,
         "-isystem/usr/local/include",
         "-isystem/opt/local/include",
+        environment<env::tag>::clang_resource_dir, // internal libraries and intrinsics
         "-isystem/usr/include",
-        "-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1",
-        "-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
         "-isystem/System/Library/Frameworks",
         "-isystem/Library/Frameworks",
         "-w",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0x970565b };
+    std::size_t constexpr const version{ 0xcfac0c1 };
     lua_pushinteger(lua, version);
     return 1;
   }


### PR DESCRIPTION
Prelude: header files are a total mess with so much history burden.

Thanks to the _ingenious_ `#include_next` hack widely used inside STL (c.f. [wrapper headers](https://gcc.gnu.org/onlinedocs/cpp/Wrapper-Headers.html)), the order of search paths does matter, unfortunately. The most important rule for C++ projects is: always include C++ STL headers __before__ system/C headers, as C++ STL will often `#include_next` the underlying C APIs, wrap them, undefine the names from the C headers, and finally redefine the names to the wrappers, in order to achieve things like precise overloads.

If we switch around the order, things will break miserably, which could easily happen right now if anyone (or some tool) puts `-isystem /usr/include` in `.color_coded`. Here's a simple test case:

In an empty folder, `test.cpp`:

```cpp
#include <iostream>
#include <cmath>

int main() {
	std::cout << log2f(0.0) << std::endl;
	return 0;
}
```

`.color_coded`:

```
-isystem
/usr/include
```

(C++ headers will be appended to the search path by `defautlts.hpp`.)

And then you will see errors similar to those in #139 and #130 . In fact, I speculate this is the root cause of those two issues. Yet I don't have a Mac to be sure.