### PR TITLE
Various fixes regarding pre/post additions to compilation args

### DIFF
--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0x1e45015
+let s:color_coded_api_version = 0x3195a52
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0x3195a52
+let s:color_coded_api_version = 0xba89eb5
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0x8c52560
+let s:color_coded_api_version = 0xebbf544
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0xaf30fa9
+let s:color_coded_api_version = 0x1e45015
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0xebbf544
+let s:color_coded_api_version = 0xaf30fa9
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0xcfac0c1
+let s:color_coded_api_version = 0x8c52560
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/include/conf/defaults.hpp
+++ b/include/conf/defaults.hpp
@@ -79,14 +79,15 @@ namespace color_coded
 
     /* Add system defaults to user specified arguments. Needed because libclang
      * often fails to find system search paths. */
-    void add_defaults_to_args(std::string const &filetype, args_t &args)
+    args_t add_defaults_to_args(std::string const &filetype, args_t &args)
     {
-      auto const pre_additions(pre_constants(filetype));
+      auto final_args(pre_constants(filetype));
       static auto const post_additions(post_constants());
-      std::copy(std::begin(pre_additions), std::end(pre_additions),
-                std::back_inserter(args));
+
+      std::move(std::begin(args), std::end(args), std::back_inserter(final_args));
       std::copy(std::begin(post_additions), std::end(post_additions),
-                std::back_inserter(args));
+                std::back_inserter(final_args));
+      return final_args;
     }
 
     /* If no .color_coded file is provided, these are used. */
@@ -94,8 +95,7 @@ namespace color_coded
     {
       // Heuristic local includes.
       args_t args{ "-I.", "-Iinclude" };
-      add_defaults_to_args(filetype, args);
-      return args;
+      return add_defaults_to_args(filetype, args);
     }
   }
 }

--- a/include/conf/defaults.hpp
+++ b/include/conf/defaults.hpp
@@ -20,9 +20,11 @@ namespace color_coded
         /* Local clang+llvm */
         environment<env::tag>::clang_include_cpp,
         environment<env::tag>::clang_include,
+#ifdef __APPLE__
         /* System clang on macOS */
         "-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1",
         "-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
+#endif
       };
 
       if(filetype == "c")
@@ -70,8 +72,10 @@ namespace color_coded
         "-isystem/opt/local/include",
         environment<env::tag>::clang_resource_dir, // internal libraries and intrinsics
         "-isystem/usr/include",
+#ifdef __APPLE__
         "-isystem/System/Library/Frameworks",
         "-isystem/Library/Frameworks",
+#endif
         "-w",
         "-fcolor-diagnostics" // See https://github.com/jeaye/color_coded/issues/104
       };

--- a/include/conf/defaults.hpp
+++ b/include/conf/defaults.hpp
@@ -83,15 +83,15 @@ namespace color_coded
 
     /* Add system defaults to user specified arguments. Needed because libclang
      * often fails to find system search paths. */
-    args_t add_defaults_to_args(std::string const &filetype, args_t &args)
+    inline args_t add_defaults_to_args(std::string const &filetype, args_t &&args)
     {
-      auto final_args(pre_constants(filetype));
+      auto pre_additions(pre_constants(filetype));
       static auto const post_additions(post_constants());
 
-      std::move(std::begin(args), std::end(args), std::back_inserter(final_args));
+      args.insert(args.begin(), pre_additions.begin(), pre_additions.end());
       std::copy(std::begin(post_additions), std::end(post_additions),
-                std::back_inserter(final_args));
-      return final_args;
+                std::back_inserter(args));
+      return std::move(args);
     }
 
     /* If no .color_coded file is provided, these are used. */
@@ -99,7 +99,7 @@ namespace color_coded
     {
       // Heuristic local includes.
       args_t args{ "-I.", "-Iinclude" };
-      return add_defaults_to_args(filetype, args);
+      return add_defaults_to_args(filetype, std::move(args));
     }
   }
 }

--- a/include/conf/defaults.hpp
+++ b/include/conf/defaults.hpp
@@ -77,16 +77,24 @@ namespace color_coded
       };
     }
 
-    /* If no .color_coded file is provided, these are used. */
-    inline args_t defaults(std::string const &filetype)
+    /* Add system defaults to user specified arguments. Needed because libclang
+     * often fails to find system search paths. */
+    void add_defaults_to_args(std::string const &filetype, args_t &args)
     {
       auto const pre_additions(pre_constants(filetype));
       static auto const post_additions(post_constants());
-      args_t args{ "-I.", "-Iinclude" };
       std::copy(std::begin(pre_additions), std::end(pre_additions),
                 std::back_inserter(args));
       std::copy(std::begin(post_additions), std::end(post_additions),
                 std::back_inserter(args));
+    }
+
+    /* If no .color_coded file is provided, these are used. */
+    inline args_t defaults(std::string const &filetype)
+    {
+      // Heuristic local includes.
+      args_t args{ "-I.", "-Iinclude" };
+      add_defaults_to_args(filetype, args);
       return args;
     }
   }

--- a/include/conf/load.hpp
+++ b/include/conf/load.hpp
@@ -93,14 +93,13 @@ namespace color_coded
       return commands;
     }
 
-    inline args_t load_color_coded(std::string const &file, std::string const &filetype)
+    inline args_t load_color_coded(std::string const &file)
     {
       std::ifstream ifs{ file };
       if(!ifs.is_open())
       { return {}; }
 
-      auto const pre_additions(pre_constants(filetype));
-      args_t args{ pre_additions };
+      args_t args;
 
       auto const &base(fs::path{ file }.parent_path());
       std::string tmp;
@@ -115,19 +114,16 @@ namespace color_coded
       if(file.empty())
       { return defaults(filetype); }
 
-      static auto const post_additions(post_constants());
-
       args_t args;
       if (fs::path(file).filename() == "compile_commands.json")
       { args = load_compilation_database(file, filename); }
       else
-      { args = load_color_coded(file, filetype); }
+      { args = load_color_coded(file); }
 
       if(args.empty())
       { return defaults(filetype); }
 
-      std::copy(post_additions.begin(), post_additions.end(),
-                std::back_inserter(args));
+      add_defaults_to_args(filetype, args);
 
       return args;
     }

--- a/include/conf/load.hpp
+++ b/include/conf/load.hpp
@@ -123,9 +123,7 @@ namespace color_coded
       if(args.empty())
       { return defaults(filetype); }
 
-      add_defaults_to_args(filetype, args);
-
-      return args;
+      return add_defaults_to_args(filetype, args);
     }
 
     inline args_t load(std::string const &file, std::string const &filetype)

--- a/include/conf/load.hpp
+++ b/include/conf/load.hpp
@@ -127,7 +127,7 @@ namespace color_coded
       if(args.empty())
       { return defaults(filetype); }
 
-      return add_defaults_to_args(filetype, args);
+      return add_defaults_to_args(filetype, std::move(args));
     }
 
     inline args_t load(std::string const &file, std::string const &filetype)

--- a/include/conf/load.hpp
+++ b/include/conf/load.hpp
@@ -87,7 +87,11 @@ namespace color_coded
       if(compile_commands.empty())
       { return {}; }
 
-      auto commands(compile_commands[0].CommandLine);
+      // Skip argv[0] which is the name of the clang executable.
+      args_t commands((compile_commands[0].CommandLine.begin() + 1), compile_commands[0].CommandLine.end());
+
+      // Get rid of the source filename itself.
+      // NOTE: '-o <output>' and '-c' will be automatically ignored by libclang.
       commands.erase(std::remove(commands.begin(), commands.end(), filename), commands.end());
 
       return commands;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0xaf30fa9 };
+    std::size_t constexpr const version{ 0x1e45015 };
     lua_pushinteger(lua, version);
     return 1;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0x3195a52 };
+    std::size_t constexpr const version{ 0xba89eb5 };
     lua_pushinteger(lua, version);
     return 1;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0x1e45015 };
+    std::size_t constexpr const version{ 0x3195a52 };
     lua_pushinteger(lua, version);
     return 1;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0xcfac0c1 };
+    std::size_t constexpr const version{ 0x8c52560 };
     lua_pushinteger(lua, version);
     return 1;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0x8c52560 };
+    std::size_t constexpr const version{ 0xebbf544 };
     lua_pushinteger(lua, version);
     return 1;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0xebbf544 };
+    std::size_t constexpr const version{ 0xaf30fa9 };
     lua_pushinteger(lua, version);
     return 1;
   }

--- a/test/include/config.hpp
+++ b/test/include/config.hpp
@@ -152,4 +152,28 @@ namespace jest
       color_coded::conf::defaults("c++")
     );
   }
+
+  template <> template <>
+  void color_coded::config_group::test<8>() /* Constants still present with compilation database. */
+  {
+    auto const args(color_coded::conf::load(compile_commands, "c++", test_file));
+    for(auto const &constant : color_coded::conf::pre_constants("c++"))
+    { expect(std::find(args.begin(), args.end(), constant) != args.end()); }
+    for(auto const &constant : color_coded::conf::post_constants())
+    { expect(std::find(args.begin(), args.end(), constant) != args.end()); }
+  }
+
+  template <> template <>
+  void color_coded::config_group::test<9>() /* Pre/post constants in the right positions. */
+  {
+    auto const args(color_coded::conf::load(test_config, "c++"));
+    auto const pre_constants(color_coded::conf::pre_constants("c++"));
+    auto const post_constants(color_coded::conf::post_constants());
+    // The first arg should be a pre-constant.
+    expect(std::find(pre_constants.begin(), pre_constants.end(),*args.begin())
+           != pre_constants.end());
+    // The last arg should be a post-constant.
+    expect(std::find(post_constants.begin(), post_constants.end(),*(args.end() - 1))
+           != post_constants.end());
+  }
 }


### PR DESCRIPTION
I noticed a few issues in the current implementation. Here are the notes in the same order of the commit history:

1. Previously, when compilation database was found, only post-constants would be added; pre-constants were ignored (a by-product of the two PRs developed in parallel).
2. Then I noticed that pre-constants were not actually prepended to arg list as intended, but appended before post-constants.
3. Tests added for 1 & 2.
4. Minor optimization (only include mac-specific paths on macOS).
5. Fix for an unexpected internal error happened due to 1. See the commit comment for details.