### PR TITLE
Strip llvm variables of whitespace

### DIFF
--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -188,6 +188,9 @@ endif()
 string(REGEX REPLACE "([0-9]+).*" "\\1" LLVM_VERSION_MAJOR "${LLVM_VERSION_STRING}" )
 string(REGEX REPLACE "[0-9]+\\.([0-9]+).*[A-Za-z]*" "\\1" LLVM_VERSION_MINOR "${LLVM_VERSION_STRING}" )
 
+string(STRIP "${LLVM_LDFLAGS}" LLVM_LDFLAGS)
+string(STRIP "${LLVM_LIBRARIES}" LLVM_LIBRARIES)
+
 # Use the default CMake facilities for handling QUIET/REQUIRED.
 include(FindPackageHandleStandardArgs)
 


### PR DESCRIPTION
llvm-config for llvm 4 seems to cause additional whitespace to appear in
the LLVM_LDFLAGS. As this is an error in CMake we should strip the LLVM
variables we use of their whitespace to avoid problems in the future.

Note that we currently do not support clang/llvm 4 because the public signature of JSONCompilationDatabase::loadFromFile has changed.