### PR TITLE
Add support for llvm 4.0

### DIFF
--- a/include/conf/load.hpp
+++ b/include/conf/load.hpp
@@ -48,7 +48,26 @@ namespace color_coded
       static const std::string source_extensions[] {".c", ".cpp", ".cc"};
       static const std::string header_extensions[] {".h", ".hpp", ".hh"};
       std::string error;
-      auto const database_ptr(::clang::tooling::JSONCompilationDatabase::loadFromFile(file, error));
+#if LLVM_VERSION_MAJOR >= 4
+      auto const database_ptr
+      (
+        ::clang::tooling::JSONCompilationDatabase::loadFromFile
+        (
+          file,
+          error,
+          ::clang::tooling::JSONCommandLineSyntax::Gnu
+        )
+      );
+#else
+      auto const database_ptr
+      (
+        ::clang::tooling::JSONCompilationDatabase::loadFromFile
+        (
+          file,
+          error
+        )
+      );
+#endif
       if(!database_ptr)
       {
           core::last_error(error);


### PR DESCRIPTION
LLVM 4 has changed the function signature of loadFromFile to include a
syntax parameter that dictates how the command line of the compilation
database commands should be parsed. Seeing how the autodetection seems
to be flaky as indicated by the commit that introduced the change, we
should set the syntax to "Gnu" instead of "autodetect" to avoid problems
with our supported platforms.
This does of course mean that we can not support JSON compilation
databases on windows using llvm 4 or higher.