### PR TITLE
Fix compilation database with relative paths

### DIFF
--- a/include/conf/load.hpp
+++ b/include/conf/load.hpp
@@ -112,6 +112,7 @@ namespace color_coded
       // Get rid of the source filename itself.
       // NOTE: '-o <output>' and '-c' will be automatically ignored by libclang.
       commands.erase(std::remove(commands.begin(), commands.end(), filename), commands.end());
+      commands.erase(std::remove(commands.begin(), commands.end(), compile_commands[0].Filename), commands.end());
 
       return commands;
     }


### PR DESCRIPTION
Fixes #162
Loading a file that has a relative path in the compile arguments will
fail with an internal error because we only try to find and remove the
absolute path of the file from the compilation arguments.

Now we also try to remove the relative filename if both "file" and the
"command" contain paths relative to the "directory".

Note that this will fail in the case that the "file" is an absolute path
and the "argument" is still relative. For this to work we would have to
make the filename itself a relative path using something like
boost::filesystem::relative, which only got introduced in boost 1.6.