### PR TITLE
Make compile_commands.json paths also absolute.

### DIFF
--- a/autoload/color_coded.vim
+++ b/autoload/color_coded.vim
@@ -4,7 +4,7 @@
 " Setup
 " ------------------------------------------------------------------------------
 
-let s:color_coded_api_version = 0xba89eb5
+let s:color_coded_api_version = 0x16e71d6
 let s:color_coded_valid = 1
 let s:color_coded_unique_counter = 1
 let g:color_coded_matches = {}

--- a/include/conf/load.hpp
+++ b/include/conf/load.hpp
@@ -114,6 +114,11 @@ namespace color_coded
       commands.erase(std::remove(commands.begin(), commands.end(), filename), commands.end());
       commands.erase(std::remove(commands.begin(), commands.end(), compile_commands[0].Filename), commands.end());
 
+      // Make these paths relative to the working directory.
+      for (auto &cmd : commands) {
+          cmd = detail::make_absolute(cmd, fs::path(compile_commands[0].Directory));
+      }
+
       return commands;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ namespace color_coded
 
   static int api_version(lua_State * const lua)
   {
-    std::size_t constexpr const version{ 0xba89eb5 };
+    std::size_t constexpr const version{ 0x16e71d6 };
     lua_pushinteger(lua, version);
     return 1;
   }


### PR DESCRIPTION
This fixes a ton of issues for me. My usual workflow is as follows:

```sh
mkdir build
cd build
cmake ..
cd ..
ln -s build/compile_commands.json .
```
Such that I have sym-linked `compile_commands.json` file in my project root. This file is automatically synced by the build folder, which is perfect. Color_coded however, does not correctly interpret the paths, as they are all relative to the `"working_directory"` entry of the `compile_commands.json` file. My pull request fixes this.